### PR TITLE
Hide other distribution modules from PAUSE

### DIFF
--- a/lib/Test/Mock/HTTP/Request.pm
+++ b/lib/Test/Mock/HTTP/Request.pm
@@ -38,7 +38,8 @@ $Mock_req->set_always('content', '');
 sub new { $Mock_req };
 $Mock_req->mock('-new_args', sub { delete $Mock_req->{new_args} });
 
-package HTTP::Request;
+package # hide from PAUSE
+    HTTP::Request;
 
 our $VERSION = 'Mocked';
 

--- a/lib/Test/Mock/HTTP/Response.pm
+++ b/lib/Test/Mock/HTTP/Response.pm
@@ -38,7 +38,8 @@ $Mock_resp->set_always('code', 200);
 $Mock_resp->set_always('content', '');
 $Mock_resp->set_always('is_success', 1);
 
-package HTTP::Response;
+package # hide from PAUSE
+    HTTP::Response;
 
 our $VERSION = 'Mocked';
 

--- a/lib/Test/Mock/LWP/UserAgent.pm
+++ b/lib/Test/Mock/LWP/UserAgent.pm
@@ -36,7 +36,8 @@ BEGIN {
 $Mock_ua->set_always('simple_request', HTTP::Response->new);
 $Mock_ua->set_always('request', HTTP::Response->new);
 
-package LWP::UserAgent;
+package # hide from PAUSE
+    LWP::UserAgent;
 use strict;
 use warnings;
 


### PR DESCRIPTION
HTTP::Request, HTTP::Response and LWP::UserAgent are other distribution 
modules, but it's indexed by PAUSE.  It causes problem when manage modules
dependency by cpanm or Carton.

I fix it by "hide from PAUSE" hack.
