### PR TITLE
Fix RT #121706

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
+0.08 - Thu Jun 14 17:24:45 PDT 2018
+ - Fix RT ticket #121706: Makefile.PL fails without '.' in @INC
+   Add '.' to @INC for Makefile.PL only
+
 0.07 - Mon Oct 14 20:41:41 PDT 2013
  - Hide other distribution modules from PAUSE - via shibayu36
+
 0.06 - Sat Jul 16 10:26:33 PDT 2011
  - Update Makefile.PL and META.yml for RT #69466
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,6 @@
 #!/usr/bin/perl -w
+BEGIN { push @INC, '.' }
+
 use warnings;
 use strict;
 use inc::Module::Install;

--- a/lib/Test/Mock/LWP.pm
+++ b/lib/Test/Mock/LWP.pm
@@ -59,7 +59,7 @@ The mock HTTP::Response object - a Test::MockObject object
 
 =cut
 
-our $VERSION = '0.07';
+our $VERSION = '0.08';
 
 BEGIN {
     # Don't load the mock classes if the real ones are already loaded


### PR DESCRIPTION
Makefile.PL fails unless `.` is in `@INC`. Add `.` to `@INC` only
for that script.